### PR TITLE
Add PyFuture.__repr__ and PyTask.__repr__

### DIFF
--- a/src/pyfuture.rs
+++ b/src/pyfuture.rs
@@ -1,6 +1,7 @@
 #![allow(unused_variables)]
 
 use std::cell;
+use std::fmt;
 use cpython::*;
 use futures::{future, unsync, Poll};
 use futures::unsync::oneshot;
@@ -16,6 +17,17 @@ pub enum State {
     Pending,
     Cancelled,
     Finished,
+}
+
+impl fmt::Display for State {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let state = match *self {
+            State::Pending => "pending",
+            State::Cancelled => "cancelled",
+            State::Finished => "finished"
+        };
+        write!(f, "{}", state)
+    }
 }
 
 pub type Callback = SendBoxFnOnce<(PyResult<PyObject>,)>;
@@ -296,7 +308,7 @@ impl _PyFuture {
             }
         }
     }
-    
+
     //
     // Mark the future done and set its result.
     //
@@ -675,6 +687,10 @@ py_class!(pub class PyFuture |py| {
 
     def __clear__(&self) {
         let _ = self._fut(py).borrow_mut().callbacks.take();
+    }
+
+    def __repr__(&self) -> PyResult<String> {
+        Ok(format!("<Future {}>", self.state(py)))
     }
 
     // handler for asyncio.Future completion

--- a/src/pytask.rs
+++ b/src/pytask.rs
@@ -165,6 +165,11 @@ py_class!(pub class PyTask |py| {
         let _ = self._fut(py).borrow_mut().callbacks.take();
     }
 
+    def __repr__(&self) -> PyResult<String> {
+        let future = self._fut(py).borrow();
+        Ok(format!("<Task {}>", future.state()))
+    }
+
     // compatibility
     property _loop {
         get(&slf) -> PyResult<TokioEventLoop> {


### PR DESCRIPTION
Ref #20 

Really just a naive implementation, a lot more could be added to be more like asyncio's.

https://github.com/python/cpython/blob/master/Lib/asyncio/base_futures.py#L54
https://github.com/python/cpython/blob/master/Lib/asyncio/base_tasks.py#L8