### PR TITLE
Add benchmark scripts adopted from uvloop

### DIFF
--- a/benchmark/echoclient.py
+++ b/benchmark/echoclient.py
@@ -1,0 +1,82 @@
+# Copied with minimal modifications from curio
+# https://github.com/dabeaz/curio
+
+
+import argparse
+import time
+
+from concurrent.futures import ProcessPoolExecutor
+from socket import *
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--msize', default=1000, type=int,
+                        help='message size in bytes')
+    parser.add_argument('--mpr', default=1, type=int,
+                        help='messages per request')
+    parser.add_argument('--num', default=200000, type=int,
+                        help='number of messages')
+    parser.add_argument('--times', default=1, type=int,
+                        help='number of times to run the test')
+    parser.add_argument('--workers', default=3, type=int,
+                        help='number of workers')
+    parser.add_argument('--addr', default='127.0.0.1:25000', type=str,
+                        help='address:port of echoserver')
+    args = parser.parse_args()
+
+    unix = False
+    if args.addr.startswith('file:'):
+        unix = True
+        addr = args.addr[5:]
+    else:
+        addr = args.addr.split(':')
+        addr[1] = int(addr[1])
+        addr = tuple(addr)
+    print('will connect to: {}'.format(addr))
+
+    MSGSIZE = args.msize
+    REQSIZE = MSGSIZE * args.mpr
+
+    msg = b'x'*(MSGSIZE - 1) + b'\n'
+    if args.mpr:
+        msg *= args.mpr
+
+    def run_test(n):
+        print('Sending', NMESSAGES, 'messages')
+        if args.mpr:
+            n //= args.mpr
+
+        if unix:
+            sock = socket(AF_UNIX, SOCK_STREAM)
+        else:
+            sock = socket(AF_INET, SOCK_STREAM)
+
+        try:
+            sock.setsockopt(IPPROTO_TCP, TCP_NODELAY, 1)
+        except (OSError, NameError):
+            pass
+
+        sock.connect(addr)
+        while n > 0:
+            sock.sendall(msg)
+            nrecv = 0
+            while nrecv < REQSIZE:
+                resp = sock.recv(REQSIZE)
+                if not resp:
+                    raise SystemExit()
+                nrecv += len(resp)
+            n -= 1
+
+    TIMES = args.times
+    N = args.workers
+    NMESSAGES = args.num
+    start = time.time()
+    for _ in range(TIMES):
+        with ProcessPoolExecutor(max_workers=N) as e:
+            for _ in range(N):
+                e.submit(run_test, NMESSAGES)
+    end = time.time()
+    duration = end-start
+    print(NMESSAGES*N*TIMES,'in', duration)
+    print(NMESSAGES*N*TIMES/duration, 'requests/sec')

--- a/benchmark/echoserver.py
+++ b/benchmark/echoserver.py
@@ -1,0 +1,167 @@
+import argparse
+import asyncio
+import gc
+import os.path
+import socket as socket_module
+
+from socket import *
+
+
+PRINT = 0
+
+
+async def echo_server(loop, address, unix):
+    if unix:
+        sock = socket(AF_UNIX, SOCK_STREAM)
+    else:
+        sock = socket(AF_INET, SOCK_STREAM)
+        sock.setsockopt(SOL_SOCKET, SO_REUSEADDR, 1)
+    sock.bind(address)
+    sock.listen(5)
+    sock.setblocking(False)
+    if PRINT:
+        print('Server listening at', address)
+    with sock:
+        while True:
+            client, addr = await loop.sock_accept(sock)
+            if PRINT:
+                print('Connection from', addr)
+            loop.create_task(echo_client(loop, client))
+
+
+async def echo_client(loop, client):
+    try:
+        client.setsockopt(IPPROTO_TCP, TCP_NODELAY, 1)
+    except (OSError, NameError):
+        pass
+
+    with client:
+        while True:
+            data = await loop.sock_recv(client, 1000000)
+            if not data:
+                break
+            await loop.sock_sendall(client, data)
+    if PRINT:
+        print('Connection closed')
+
+
+async def echo_client_streams(reader, writer):
+    sock = writer.get_extra_info('socket')
+    try:
+        sock.setsockopt(IPPROTO_TCP, TCP_NODELAY, 1)
+    except (OSError, NameError):
+        pass
+    if PRINT:
+        print('Connection from', sock.getpeername())
+    while True:
+        data = await reader.read(1000000)
+        if not data:
+            break
+        writer.write(data)
+    if PRINT:
+        print('Connection closed')
+    writer.close()
+
+
+class EchoProtocol(asyncio.Protocol):
+    def connection_made(self, transport):
+        self.transport = transport
+
+    def connection_lost(self, exc):
+        self.transport = None
+
+    def data_received(self, data):
+        self.transport.write(data)
+
+
+async def print_debug(loop):
+    while True:
+        print(chr(27) + "[2J")  # clear screen
+        loop.print_debug_info()
+        await asyncio.sleep(0.5, loop=loop)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--uvloop', default=False, action='store_true')
+    parser.add_argument('--tokio', default=False, action='store_true')
+    parser.add_argument('--streams', default=False, action='store_true')
+    parser.add_argument('--proto', default=False, action='store_true')
+    parser.add_argument('--addr', default='127.0.0.1:25000', type=str)
+    parser.add_argument('--print', default=False, action='store_true')
+    args = parser.parse_args()
+
+    if args.uvloop:
+        import uvloop
+        loop = uvloop.new_event_loop()
+        print('using UVLoop')
+    elif args.tokio:
+        import tokio
+
+        policy = tokio.EventLoopPolicy()
+        asyncio.set_event_loop_policy(policy)
+        loop = tokio.new_event_loop()
+        print('using tokio loop')
+    else:
+        loop = asyncio.new_event_loop()
+        print('using asyncio loop')
+
+    asyncio.set_event_loop(loop)
+    loop.set_debug(False)
+
+    if args.print:
+        PRINT = 1
+
+    if hasattr(loop, 'print_debug_info'):
+        loop.create_task(print_debug(loop))
+        PRINT = 0
+
+    unix = False
+    if args.addr.startswith('file:'):
+        unix = True
+        addr = args.addr[5:]
+        if os.path.exists(addr):
+            os.remove(addr)
+    else:
+        addr = args.addr.split(':')
+        addr[1] = int(addr[1])
+        addr = tuple(addr)
+
+    print('serving on: {}'.format(addr))
+
+    if args.streams:
+        if args.proto:
+            print('cannot use --stream and --proto simultaneously')
+            exit(1)
+
+        print('using asyncio/streams')
+        if unix:
+            coro = asyncio.start_unix_server(echo_client_streams,
+                                             addr, loop=loop)
+        else:
+            coro = asyncio.start_server(echo_client_streams,
+                                        *addr, loop=loop)
+        srv = loop.run_until_complete(coro)
+    elif args.proto:
+        if args.streams:
+            print('cannot use --stream and --proto simultaneously')
+            exit(1)
+
+        print('using simple protocol')
+        if unix:
+            coro = loop.create_unix_server(EchoProtocol, addr)
+        else:
+            coro = loop.create_server(EchoProtocol, *addr)
+        srv = loop.run_until_complete(coro)
+    else:
+        print('using sock_recv/sock_sendall')
+        loop.create_task(echo_server(loop, addr, unix))
+    try:
+        loop.run_forever()
+    finally:
+        if hasattr(loop, 'print_debug_info'):
+            gc.collect()
+            print(chr(27) + "[2J")
+            loop.print_debug_info()
+
+        loop.close()

--- a/benchmark/rlserver.py
+++ b/benchmark/rlserver.py
@@ -1,0 +1,102 @@
+import argparse
+import asyncio
+import gc
+import os.path
+import socket as socket_module
+
+from socket import *
+
+
+PRINT = 0
+
+
+async def echo_client_streams(reader, writer):
+    sock = writer.get_extra_info('socket')
+    try:
+        sock.setsockopt(IPPROTO_TCP, TCP_NODELAY, 1)
+    except (OSError, NameError):
+        pass
+    if PRINT:
+        print('Connection from', sock.getpeername())
+    while True:
+        data = await reader.readline()
+        if not data:
+            break
+        writer.write(data)
+    if PRINT:
+        print('Connection closed')
+    writer.close()
+
+
+async def print_debug(loop):
+    while True:
+        print(chr(27) + "[2J")  # clear screen
+        loop.print_debug_info()
+        await asyncio.sleep(0.5, loop=loop)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--uvloop', default=False, action='store_true')
+    parser.add_argument('--tokio', default=False, action='store_true')
+    parser.add_argument('--addr', default='127.0.0.1:25000', type=str)
+    parser.add_argument('--print', default=False, action='store_true')
+    args = parser.parse_args()
+
+    if args.uvloop:
+        import uvloop
+        loop = uvloop.new_event_loop()
+        print('using UVLoop')
+    elif args.tokio:
+        import tokio
+
+        policy = tokio.EventLoopPolicy()
+        asyncio.set_event_loop_policy(policy)
+        loop = tokio.new_event_loop()
+        print('using tokio loop')
+    else:
+        loop = asyncio.new_event_loop()
+        print('using asyncio loop')
+
+    asyncio.set_event_loop(loop)
+    loop.set_debug(False)
+
+    if args.print:
+        PRINT = 1
+
+    if hasattr(loop, 'print_debug_info'):
+        loop.create_task(print_debug(loop))
+        PRINT = 0
+
+    unix = False
+    if args.addr.startswith('file:'):
+        unix = True
+        addr = args.addr[5:]
+        if os.path.exists(addr):
+            os.remove(addr)
+    else:
+        addr = args.addr.split(':')
+        addr[1] = int(addr[1])
+        addr = tuple(addr)
+
+    print('readline performance test')
+    print('serving on: {}'.format(addr))
+
+    print('using asyncio/streams')
+    if unix:
+        coro = asyncio.start_unix_server(echo_client_streams,
+                                         addr, loop=loop, limit=256000)
+    else:
+        coro = asyncio.start_server(echo_client_streams,
+                                    *addr, loop=loop, limit=256000)
+    srv = loop.run_until_complete(coro)
+
+    try:
+        loop.run_forever()
+    finally:
+        if hasattr(loop, 'print_debug_info'):
+            gc.collect()
+            print(chr(27) + "[2J")
+            loop.print_debug_info()
+
+        loop.close()


### PR DESCRIPTION
Tried running `echoserver` and `echoclient` locally.

Start server:

```bash
python echoserver.py --tokio
```

Memory usage before running benchmark:

<img width="788" alt="start-echserver 2x" src="https://user-images.githubusercontent.com/1556054/28346629-c6e27a90-6c64-11e7-9a4a-c28b2273cfa6.png">

Start client:

```bash
python echoclient.py --addr 127.0.0.1:25000
```

Memory usage after running benchmark:

<img width="801" alt="after-benchmark1 2x" src="https://user-images.githubusercontent.com/1556054/28346633-d4322bc8-6c64-11e7-951d-c137fa002a10.png">

Possible memory leaks? I tried run `echoserver` with `asyncio` event loop, it has no such problem.

cc #43 