### PR TITLE
fix TypeError with use pyo3 0.2.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ dependencies = [
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
- "pyo3 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pyo3 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-signal 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -235,13 +235,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "pyo3"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "pyo3cls 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pyo3cls 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "spin 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -249,10 +249,10 @@ dependencies = [
 
 [[package]]
 name = "pyo3cls"
-version = "0.2.1"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -474,8 +474,8 @@ dependencies = [
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
 "checksum net2 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)" = "3a80f842784ef6c9a958b68b7516bc7e35883c614004dd94959a4dca1b716c09"
 "checksum num-traits 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c22f20a157cb4af265c71e47db525852368feeb4a0013f0f8c68a7f4ef0d0fc1"
-"checksum pyo3 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "1e74c3e810d713cc6d2517b80759acd025908a0a473b091308d5a2399552633b"
-"checksum pyo3cls 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0c190ba1622d96775be7adc2d77cf834560985141e2007f9688d263a43a4b4c5"
+"checksum pyo3 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "749bb59f0e5a9fbe6d648a445fb5bce4105a9dab6f4198e9b8d48ce6428ecd24"
+"checksum pyo3cls 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "14651f0239389e1ee1a6c43c1cd3091fd36afae53194249205913649099359b0"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum rand 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)" = "6475140dfd8655aeb72e1fd4b7a1cc1c202be65d71669476e392fe62532b9edd"
 "checksum regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1731164734096285ec2a5ec7fea5248ae2f5485b3feeb0115af4fda2183b2d1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ tokio-signal = "0.1"
 tokio-uds = "0.1"
 
 [dependencies.pyo3]
-version = "^0.2.6"
+version = "^0.2.7"
 features = ["python3"]
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@ pub use server::create_server;
 pub use client::create_connection;
 
 
-#[py::modinit("_tokio")]
+#[py::modinit(_tokio)]
 /// Asyncio event loop based on tokio-rs
 fn init_async_tokio(py: Python, m: &PyModule) -> PyResult<()> {
     let _ = env_logger::init();


### PR DESCRIPTION

error occured with following code:
```python
Traceback (most recent call last):
  File "usetokioloop.py", line 1, in <module>
    import tokio
  File "/path/to/tokio/__init__.py", line 14, in <module>
    class Loop(_tokio.TokioEventLoop, AbstractEventLoop):
TypeError: type 'tokio._tokio.TokioEventLoop' is not an acceptable base type
```

usetokioloop.py
```python
import tokio

tokio.EventLoopPolicy()
```

Thanks